### PR TITLE
Reordered parameters

### DIFF
--- a/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
@@ -24,14 +24,12 @@ public class PartyInteractionDelegate implements PartyInteractionApiDelegate {
     public ResponseEntity<PartyInteractionType> createPartyInteraction(PartyInteractionType partyInteractionRequestType,
                                                                        String profile) {
         return createPartyInteractionInteranal(profile, partyInteractionRequestType);
-
     }
 
     @LogicExtensionPoint(value = "PartyInteractionCreate", resolver = ProfileKeyResolver.class)
     private ResponseEntity<PartyInteractionType> createPartyInteractionInteranal(String profile,
                                                                                  PartyInteractionType partyInteractionRequestType) {
         return ResponseEntity.ok(new PartyInteractionType());
-
     }
 
     @Timed

--- a/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
@@ -33,7 +33,6 @@ public class PartyInteractionDelegate implements PartyInteractionApiDelegate {
     }
 
     @Timed
-    @LogicExtensionPoint(value = "PartyInteractionRetrieve", resolver = ProfileKeyResolver.class)
     @PreAuthorize("hasPermission({'profile': #profile}, 'INTERACTION.GET')")
     @Override
     public ResponseEntity<PartyInteractionType> retrievePartyInteraction(String partyInteractionId, String profile) {

--- a/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
@@ -19,11 +19,17 @@ import java.util.List;
 public class PartyInteractionDelegate implements PartyInteractionApiDelegate {
 
     @Timed
-    @LogicExtensionPoint(value = "PartyInteractionCreate", resolver = ProfileKeyResolver.class)
     @PreAuthorize("hasPermission({'profile': #profile}, 'INTERACTION.ADD')")
     @Override
     public ResponseEntity<PartyInteractionType> createPartyInteraction(PartyInteractionType partyInteractionRequestType,
                                                                        String profile) {
+        return createPartyInteractionInteranal(profile, partyInteractionRequestType);
+
+    }
+
+    @LogicExtensionPoint(value = "PartyInteractionCreate", resolver = ProfileKeyResolver.class)
+    private ResponseEntity<PartyInteractionType> createPartyInteractionInteranal(String profile,
+                                                                                 PartyInteractionType partyInteractionRequestType) {
         return ResponseEntity.ok(new PartyInteractionType());
 
     }
@@ -32,10 +38,15 @@ public class PartyInteractionDelegate implements PartyInteractionApiDelegate {
     @LogicExtensionPoint(value = "PartyInteractionRetrieve", resolver = ProfileKeyResolver.class)
     @PreAuthorize("hasPermission({'profile': #profile}, 'INTERACTION.GET')")
     @Override
-    public ResponseEntity<PartyInteractionType> retrievePartyInteraction(String profile,
-                                                                         String partyInteractionId) {
-        return ResponseEntity.ok(new PartyInteractionType());
+    public ResponseEntity<PartyInteractionType> retrievePartyInteraction(String partyInteractionId, String profile) {
+        return retrievePartyInteractionInternal(profile, partyInteractionId);
 
+    }
+
+    @LogicExtensionPoint(value = "PartyInteractionRetrieve", resolver = ProfileKeyResolver.class)
+    private ResponseEntity<PartyInteractionType> retrievePartyInteractionInternal(String profile,
+                                                                                  String partyInteractionId) {
+        return ResponseEntity.ok(new PartyInteractionType());
     }
 
     @Timed

--- a/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/interaction/web/rest/PartyInteractionDelegate.java
@@ -38,7 +38,6 @@ public class PartyInteractionDelegate implements PartyInteractionApiDelegate {
     @Override
     public ResponseEntity<PartyInteractionType> retrievePartyInteraction(String partyInteractionId, String profile) {
         return retrievePartyInteractionInternal(profile, partyInteractionId);
-
     }
 
     @LogicExtensionPoint(value = "PartyInteractionRetrieve", resolver = ProfileKeyResolver.class)


### PR DESCRIPTION
Fixes this issue: https://github.com/xm-online/tmf-ms-interaction/issues/8

1. createPartyInteraction: does not match all other methods
2. retrievePartyInteraction: does not match implemented interface

Since we cannot impact on the parameters order in the code, which generated by the Swagger code generator, I've moved LEP annotation to the 'internal' methods with the expected order of parameters.